### PR TITLE
1) Move adding vanilla items to MMDMaterial wrappers for vanilla stuf…

### DIFF
--- a/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/events/TinkersAlloyRecipeEvent.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/events/TinkersAlloyRecipeEvent.java
@@ -2,6 +2,7 @@ package com.mcmoddev.lib.integration.plugins.tinkers.events;
 
 import java.util.Optional;
 
+import com.mcmoddev.lib.MMDLib;
 import com.mcmoddev.lib.integration.plugins.tinkers.TinkersMaterial;
 
 import net.minecraftforge.fluids.FluidStack;
@@ -23,14 +24,21 @@ public class TinkersAlloyRecipeEvent extends Event {
     }
 
     public void addAlloyRecipe(TinkersMaterial material, int outputAmount, FluidStack...inputs) {
+    	for(FluidStack s : inputs) {
+    		if( s == null || s.getFluid() == null ) {
+    			MMDLib.logger.error("Alloy for {} with output amount {} contains a null input", material.getName(), outputAmount);
+    			return;
+    		}
+    	}
     	material.addAlloyRecipe(outputAmount, inputs);
     }
     
     public void addAlloyRecipe(String materialName, int outputAmount, FluidStack...inputs) {
     	Optional<TinkersMaterial> res = this.registry.getEntries().stream().filter(ent -> ent.getKey().getPath().equals(materialName))
     	.map(ent -> ent.getValue()).findFirst();
+    	
     	if(res.isPresent()) {
-    		res.get().addAlloyRecipe(outputAmount, inputs);
+    		addAlloyRecipe(res.get(), outputAmount, inputs);
     	}
     }
 }

--- a/src/main/java/com/mcmoddev/lib/util/MMDLibConfig.java
+++ b/src/main/java/com/mcmoddev/lib/util/MMDLibConfig.java
@@ -2,6 +2,7 @@ package com.mcmoddev.lib.util;
 
 import java.io.File;
 
+import com.mcmoddev.lib.data.MaterialNames;
 import com.mcmoddev.lib.MMDLib;
 import com.mcmoddev.lib.data.ConfigKeys;
 import com.mcmoddev.lib.integration.plugins.ConstructsArmory;
@@ -42,6 +43,22 @@ public class MMDLibConfig extends Config {
 			new IntegrationConfigOptions("Thermal Expansion", ThermalExpansion.PLUGIN_MODID, true)
 		};
 
+	private static final MaterialConfigOptions[] MATERIAL_CONFIG_OPTIONS = new MaterialConfigOptions[] {
+			new MaterialConfigOptions(MaterialNames.CHARCOAL, true, true, true, true),
+			new MaterialConfigOptions(MaterialNames.COAL, true, true, true,true),
+			new MaterialConfigOptions(MaterialNames.DIAMOND,true, true, true, true),
+			new MaterialConfigOptions(MaterialNames.EMERALD,true, true, true, true),
+			new MaterialConfigOptions(MaterialNames.GOLD, true,true, true, true),
+			new MaterialConfigOptions(MaterialNames.IRON, true,true, true, true),
+			new MaterialConfigOptions(MaterialNames.STONE, true,true, false, false),
+			new MaterialConfigOptions(MaterialNames.WOOD, true,true, false, false),
+			new MaterialConfigOptions(MaterialNames.ENDER, true,true, true, true),
+			new MaterialConfigOptions(MaterialNames.QUARTZ, true,true, true, true),
+			new MaterialConfigOptions(MaterialNames.OBSIDIAN,true, true, true, true),
+			new MaterialConfigOptions(MaterialNames.LAPIS, true,true, false, false),
+			new MaterialConfigOptions(MaterialNames.PRISMARINE,true, true, true, true),
+			new MaterialConfigOptions(MaterialNames.REDSTONE,true, true, true, true)
+	};
 
 	/**
 	 * Fired when the configuration changes.
@@ -114,6 +131,7 @@ public class MMDLibConfig extends Config {
 						"Enable the items for Mekanism support even if the Mekanism plugin is disabled"));
 
 		configIntegrationOptions(INTEGRATION_CONFIG_OPTIONS, configuration);
+		configMaterialOptions(MATERIAL_CONFIG_OPTIONS, configuration);
 
 		// RECIPE AMOUNTS/TOOL&ITEM DISABLING
 		Options.setGearQuantity(configuration.getInt("Gear Quantity", TOOLS_CAT, 4, 1, 64,

--- a/src/main/java/com/mcmoddev/lib/vanillasupport/VanillaSupport.java
+++ b/src/main/java/com/mcmoddev/lib/vanillasupport/VanillaSupport.java
@@ -1,0 +1,155 @@
+package com.mcmoddev.lib.vanillasupport;
+
+import com.mcmoddev.lib.MMDLib;
+import com.mcmoddev.lib.data.MaterialNames;
+import com.mcmoddev.lib.data.Names;
+import com.mcmoddev.lib.events.MMDLibRegisterBlocks;
+import com.mcmoddev.lib.events.MMDLibRegisterItems;
+import com.mcmoddev.lib.init.Materials;
+import com.mcmoddev.lib.material.MMDMaterial;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod.EventBusSubscriber(modid=MMDLib.MODID)
+public class VanillaSupport {
+
+	private VanillaSupport() {
+		// TODO Auto-generated constructor stub
+	}
+	
+	@SubscribeEvent(priority=EventPriority.HIGHEST)
+	public static void vanillaItems(MMDLibRegisterItems ev) {
+		final MMDMaterial wood = Materials.getMaterialByName(MaterialNames.WOOD);
+		final MMDMaterial stone = Materials.getMaterialByName(MaterialNames.STONE);
+		final MMDMaterial iron = Materials.getMaterialByName(MaterialNames.IRON);
+		final MMDMaterial gold = Materials.getMaterialByName(MaterialNames.GOLD);
+		final MMDMaterial diamond = Materials.getMaterialByName(MaterialNames.DIAMOND);
+
+		wood.addNewItem(Names.AXE, net.minecraft.init.Items.WOODEN_AXE);
+		wood.addNewItem(Names.DOOR, net.minecraft.init.Items.OAK_DOOR);
+		wood.addNewItem(Names.HOE, net.minecraft.init.Items.WOODEN_HOE);
+		wood.addNewItem(Names.PICKAXE, net.minecraft.init.Items.WOODEN_PICKAXE);
+		wood.addNewItem(Names.SHOVEL, net.minecraft.init.Items.WOODEN_SHOVEL);
+		wood.addNewItem(Names.SWORD, net.minecraft.init.Items.WOODEN_SWORD);
+		wood.addNewBlock(Names.DOOR, net.minecraft.init.Blocks.OAK_DOOR);
+		wood.addNewBlock(Names.ORE, net.minecraft.init.Blocks.LOG);
+		wood.addNewBlock(Names.TRAPDOOR, net.minecraft.init.Blocks.TRAPDOOR);
+		wood.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.PLANKS);
+		wood.addNewBlock(Names.SLAB, net.minecraft.init.Blocks.WOODEN_SLAB);
+		wood.addNewBlock(Names.DOUBLE_SLAB, net.minecraft.init.Blocks.DOUBLE_WOODEN_SLAB);
+		wood.addNewBlock(Names.STAIRS, net.minecraft.init.Blocks.OAK_STAIRS);
+		wood.addNewItem(Names.SHEARS, net.minecraft.init.Items.SHEARS);
+		stone.addNewItem(Names.AXE, net.minecraft.init.Items.STONE_AXE);
+		stone.addNewItem(Names.HOE, net.minecraft.init.Items.STONE_HOE);
+		stone.addNewItem(Names.PICKAXE, net.minecraft.init.Items.STONE_PICKAXE);
+		stone.addNewItem(Names.SHOVEL, net.minecraft.init.Items.STONE_SHOVEL);
+		stone.addNewItem(Names.SWORD, net.minecraft.init.Items.STONE_SWORD);
+		stone.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.STONE);
+		stone.addNewBlock(Names.SLAB, net.minecraft.init.Blocks.STONE_SLAB);
+		stone.addNewBlock(Names.DOUBLE_SLAB, net.minecraft.init.Blocks.DOUBLE_STONE_SLAB);
+		stone.addNewBlock(Names.STAIRS, net.minecraft.init.Blocks.STONE_STAIRS);
+		iron.addNewItem(Names.AXE, net.minecraft.init.Items.IRON_AXE);
+		iron.addNewItem(Names.DOOR, net.minecraft.init.Items.IRON_DOOR);
+		iron.addNewItem(Names.HOE, net.minecraft.init.Items.IRON_HOE);
+		iron.addNewItem(Names.HORSE_ARMOR, net.minecraft.init.Items.IRON_HORSE_ARMOR);
+		iron.addNewItem(Names.PICKAXE, net.minecraft.init.Items.IRON_PICKAXE);
+		iron.addNewItem(Names.SHOVEL, net.minecraft.init.Items.IRON_SHOVEL);
+		iron.addNewItem(Names.SWORD, net.minecraft.init.Items.IRON_SWORD);
+		iron.addNewItem(Names.BOOTS, net.minecraft.init.Items.IRON_BOOTS);
+		iron.addNewItem(Names.CHESTPLATE, net.minecraft.init.Items.IRON_CHESTPLATE);
+		iron.addNewItem(Names.HELMET, net.minecraft.init.Items.IRON_HELMET);
+		iron.addNewItem(Names.LEGGINGS, net.minecraft.init.Items.IRON_LEGGINGS);
+		iron.addNewItem(Names.INGOT, net.minecraft.init.Items.IRON_INGOT);
+		iron.addNewItem(Names.NUGGET, net.minecraft.init.Items.IRON_NUGGET);
+		iron.addNewItem(Names.SHEARS, net.minecraft.init.Items.SHEARS);
+		gold.addNewItem(Names.AXE, net.minecraft.init.Items.GOLDEN_AXE);
+		gold.addNewItem(Names.HOE, net.minecraft.init.Items.GOLDEN_HOE);
+		gold.addNewItem(Names.HORSE_ARMOR, net.minecraft.init.Items.GOLDEN_HORSE_ARMOR);
+		gold.addNewItem(Names.PICKAXE, net.minecraft.init.Items.GOLDEN_PICKAXE);
+		gold.addNewItem(Names.SHOVEL, net.minecraft.init.Items.GOLDEN_SHOVEL);
+		gold.addNewItem(Names.SWORD, net.minecraft.init.Items.GOLDEN_SWORD);
+		gold.addNewItem(Names.BOOTS, net.minecraft.init.Items.GOLDEN_BOOTS);
+		gold.addNewItem(Names.CHESTPLATE, net.minecraft.init.Items.GOLDEN_CHESTPLATE);
+		gold.addNewItem(Names.HELMET, net.minecraft.init.Items.GOLDEN_HELMET);
+		gold.addNewItem(Names.LEGGINGS, net.minecraft.init.Items.GOLDEN_LEGGINGS);
+		gold.addNewItem(Names.INGOT, net.minecraft.init.Items.GOLD_INGOT);
+		gold.addNewItem(Names.NUGGET, net.minecraft.init.Items.GOLD_NUGGET);
+		diamond.addNewItem(Names.AXE, net.minecraft.init.Items.DIAMOND_AXE);
+		diamond.addNewItem(Names.HOE, net.minecraft.init.Items.DIAMOND_HOE);
+		diamond.addNewItem(Names.HORSE_ARMOR, net.minecraft.init.Items.DIAMOND_HORSE_ARMOR);
+		diamond.addNewItem(Names.PICKAXE, net.minecraft.init.Items.DIAMOND_PICKAXE);
+		diamond.addNewItem(Names.SHOVEL, net.minecraft.init.Items.DIAMOND_SHOVEL);
+		diamond.addNewItem(Names.SWORD, net.minecraft.init.Items.DIAMOND_SWORD);
+		diamond.addNewItem(Names.BOOTS, net.minecraft.init.Items.DIAMOND_BOOTS);
+		diamond.addNewItem(Names.CHESTPLATE, net.minecraft.init.Items.DIAMOND_CHESTPLATE);
+		diamond.addNewItem(Names.HELMET, net.minecraft.init.Items.DIAMOND_HELMET);
+		diamond.addNewItem(Names.LEGGINGS, net.minecraft.init.Items.DIAMOND_LEGGINGS);
+		diamond.addNewItem(Names.INGOT, net.minecraft.init.Items.DIAMOND);
+		
+		Materials.getMaterialByName(MaterialNames.CHARCOAL).addNewItemFromItemStack(Names.INGOT,
+				new ItemStack(net.minecraft.init.Items.COAL, 1, 1));
+		Materials.getMaterialByName(MaterialNames.COAL).addNewItemFromItemStack(Names.INGOT,
+				new ItemStack(net.minecraft.init.Items.COAL, 1, 0));
+
+		Materials.getMaterialByName(MaterialNames.EMERALD).addNewItem(Names.INGOT,
+				net.minecraft.init.Items.EMERALD);
+		Materials.getMaterialByName(MaterialNames.LAPIS).addNewItemFromItemStack(Names.INGOT,
+				new ItemStack(net.minecraft.init.Items.DYE, 1, 4));
+		Materials.getMaterialByName(MaterialNames.QUARTZ).addNewItem(Names.INGOT,
+				net.minecraft.init.Items.QUARTZ);
+		Materials.getMaterialByName(MaterialNames.REDSTONE).addNewItem(Names.POWDER,
+				net.minecraft.init.Items.REDSTONE);
+	}
+
+	@SubscribeEvent(priority=EventPriority.HIGHEST)
+	public static void vanillaBlocks(MMDLibRegisterBlocks ev) {
+		// Vanilla Materials get their Ore and Block always
+		final MMDMaterial coal = Materials.getMaterialByName(MaterialNames.COAL);
+		final MMDMaterial diamond = Materials.getMaterialByName(MaterialNames.DIAMOND);
+		final MMDMaterial emerald = Materials.getMaterialByName(MaterialNames.EMERALD);
+		final MMDMaterial gold = Materials.getMaterialByName(MaterialNames.GOLD);
+		final MMDMaterial iron = Materials.getMaterialByName(MaterialNames.IRON);
+		final MMDMaterial lapis = Materials.getMaterialByName(MaterialNames.LAPIS);
+		final MMDMaterial obsidian = Materials.getMaterialByName(MaterialNames.OBSIDIAN);
+		final MMDMaterial quartz = Materials.getMaterialByName(MaterialNames.QUARTZ);
+		final MMDMaterial redstone = Materials.getMaterialByName(MaterialNames.REDSTONE);
+
+		coal.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.COAL_BLOCK);
+		coal.addNewBlock(Names.ORE, net.minecraft.init.Blocks.COAL_ORE);
+
+		diamond.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.DIAMOND_BLOCK);
+		diamond.addNewBlock(Names.ORE, net.minecraft.init.Blocks.DIAMOND_ORE);
+
+		emerald.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.EMERALD_BLOCK);
+		emerald.addNewBlock(Names.ORE, net.minecraft.init.Blocks.EMERALD_ORE);
+
+		gold.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.GOLD_BLOCK);
+		gold.addNewBlock(Names.ORE, net.minecraft.init.Blocks.GOLD_ORE);
+		gold.addNewBlock(Names.PRESSURE_PLATE,
+				net.minecraft.init.Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE);
+
+		iron.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.IRON_BLOCK);
+		iron.addNewBlock(Names.ORE, net.minecraft.init.Blocks.IRON_ORE);
+		iron.addNewBlock(Names.BARS, net.minecraft.init.Blocks.IRON_BARS);
+		iron.addNewBlock(Names.DOOR, net.minecraft.init.Blocks.IRON_DOOR);
+		iron.addNewBlock(Names.TRAPDOOR, net.minecraft.init.Blocks.IRON_TRAPDOOR);
+		iron.addNewBlock(Names.PRESSURE_PLATE,
+				net.minecraft.init.Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE);
+
+		lapis.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.LAPIS_BLOCK);
+		lapis.addNewBlock(Names.ORE, net.minecraft.init.Blocks.LAPIS_ORE);
+
+		obsidian.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.OBSIDIAN);
+
+		quartz.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.QUARTZ_BLOCK);
+		quartz.addNewBlock(Names.ORE, net.minecraft.init.Blocks.QUARTZ_ORE);
+		quartz.addNewBlock(Names.STAIRS, net.minecraft.init.Blocks.QUARTZ_STAIRS);
+
+		redstone.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.REDSTONE_BLOCK);
+		redstone.addNewBlock(Names.ORE, net.minecraft.init.Blocks.REDSTONE_ORE);
+	}
+
+}


### PR DESCRIPTION
…f out of BaseMetals

2) ditto for vanilla blocks
3) Make MMDLib responsible for configuring wide allocation of vanilla materials instead of BaseMetals
-- as noted in the related commit for BaseMetals, this allows for MMDLib to have vanilla stuff available for lib-users to access without providing any of the extended stuff.