### PR TITLE
1.12 Performance Fixes

### DIFF
--- a/src/main/java/com/mcmoddev/lib/data/NameToken.java
+++ b/src/main/java/com/mcmoddev/lib/data/NameToken.java
@@ -34,9 +34,6 @@ public class NameToken {
 	@Override
 	public boolean equals(Object other) {
 		if (!(other instanceof NameToken)) return false;
-		
-		NameToken ot = (NameToken) other;
-		
-		return (ot.asString().equals(this.origData) && ot.hashCode() == this.hashCode() && ot.toString().equals(this.toString()));
+		return ((NameToken)other).uuid.equals(this.uuid);
 	}
 }

--- a/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
+++ b/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
@@ -597,7 +597,7 @@ public class MMDMaterial extends IForgeRegistryEntry.Impl<MMDMaterial> {
 
 	@Nullable
 	public Item getItem(final NameToken name) {
-		ItemStack tmp = this.items.get(name);
+		final ItemStack tmp = this.items.get(name);
 		return (tmp != null) ? tmp.getItem() : null;
 	}
 	

--- a/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
+++ b/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
@@ -597,10 +597,8 @@ public class MMDMaterial extends IForgeRegistryEntry.Impl<MMDMaterial> {
 
 	@Nullable
 	public Item getItem(final NameToken name) {
-		if (this.items.containsKey(name)) {
-			return this.items.get(name).getItem();
-		}
-		return null;
+		ItemStack tmp = this.items.get(name);
+		return (tmp != null) ? tmp.getItem() : null;
 	}
 	
 	public ItemStack getItemStack(final Names name) {
@@ -669,10 +667,7 @@ public class MMDMaterial extends IForgeRegistryEntry.Impl<MMDMaterial> {
 
 	@Nullable
 	public Block getBlock(final NameToken name) {
-		if (this.blocks.containsKey(name)) {
-			return this.blocks.get(name);
-		}
-		return null;
+		return this.blocks.get(name);
 	}
 	
 	public ItemStack getBlockItemStack(final Names name) {


### PR DESCRIPTION
Fixed some redundancies which can hinder performance, such as a double lookup in the `MMDMaterial#getBlock` method and the multiple checks in `NameToken#equals`.